### PR TITLE
Fixes error "Unknown  preset: :boolean - Aborting" when trying to run scan

### DIFF
--- a/src/clj_holmes/main.clj
+++ b/src/clj_holmes/main.clj
@@ -57,7 +57,7 @@
                        :type :string
                        :as "Regex for paths and files that shouldn't be scanned"}
                       {:option "verbose" :short "v"
-                       :type :boolean
+                       :type :flag
                        :default true
                        :as "Enable or disable scan process feedback."}]
                :runs engine/scan}]})


### PR DESCRIPTION
Holmes v1.2.0 gives me an error message "Unknown  preset: :boolean - Aborting".
This change fixes that error message.
