### PR TITLE
feat: Outputs STDERR when has errors on result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ target/
 pom.xml
 .lein-failures
 reports/
+.lsp/.cache
+.clj-kondo/.cache

--- a/project.clj
+++ b/project.clj
@@ -37,7 +37,7 @@
                  [progrock "0.1.2"]
                  [org.clojars.clj-holmes/shape-shifter "0.3.6"]
                  [borkdude/edamame "0.0.15"]]
-            
+
   :profiles {:dev     {:dependencies [[org.clojure/test.check "1.1.1"]]
                        :plugins      [[lein-shell "0.5.0"]]}
              :uberjar {:global-vars {*assert* false}

--- a/src/clj_holmes/engine.clj
+++ b/src/clj_holmes/engine.clj
@@ -1,6 +1,7 @@
 (ns clj-holmes.engine
   (:require [clj-holmes.diplomat.code-reader :as diplomat.code-reader]
             [clj-holmes.logic.progress :as progress]
+            [clj-holmes.logic.result :as result]
             [clj-holmes.output.main :as output]
             [clj-holmes.rules.loader.loader :as rules.loader]
             [clj-holmes.rules.processor.processor :as rules.processor])
@@ -20,7 +21,8 @@
         scans-results (->> code-structures
                            (pmap #(check-rules-in-code-structure % rules progress-size))
                            (reduce concat))
-        scan-result-output (output/output scans-results opts)]
+        has-errors (result/has-errors? scans-results)
+        scan-result-output (output/output scans-results (assoc opts :has-errors has-errors))]
     scan-result-output))
 
 (defn scan [{:keys [verbose] :as opts}]

--- a/src/clj_holmes/logic/result.clj
+++ b/src/clj_holmes/logic/result.clj
@@ -1,0 +1,7 @@
+(ns clj-holmes.logic.result)
+
+(defn has-errors? [scans-results]
+  (-> #(= (:severity %) "error")
+      (filter scans-results)
+      count
+      (> 0)))

--- a/src/clj_holmes/output/main.clj
+++ b/src/clj_holmes/output/main.clj
@@ -23,8 +23,10 @@
     (spit output-file json-str)
     json-result))
 
-(defmethod output :stdout [results _]
+(defmethod output :stdout [results {:keys [has-errors]}]
   (let [stdout-result (output.stdout/output results)]
-    (binding [*out* (OutputStreamWriter. System/out)]
+    (binding [*out* (if has-errors
+                      (OutputStreamWriter. System/err)
+                      (OutputStreamWriter. System/out))]
       (pprint/print-table stdout-result)
       stdout-result)))

--- a/test/clj_holmes/logic/result_test.clj
+++ b/test/clj_holmes/logic/result_test.clj
@@ -1,0 +1,10 @@
+(ns clj-holmes.logic.result-test
+  (:require [clj-holmes.logic.result :as result]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest has-errors
+  (testing "when there is no error"
+    (is (= false (result/has-errors? [{:severity "warning"} {:severity "info"}]))))
+
+  (testing "when there is errors"
+    (is (= true (result/has-errors? [{:severity "warning"} {:severity "error"}])))))


### PR DESCRIPTION
I'm having a "problem" when using clj-holmes on github-actions it isn't triggering the fail state, I thing we need to redirect the output to STDERR instead normal STDOUT when we want to fail our pipelines.

![image](https://user-images.githubusercontent.com/1683898/145866064-4b72afff-5667-48f3-8e8a-4fa325b8b2d2.png)
