### PR TITLE
Consider case where parent is nil

### DIFF
--- a/src/clj_holmes/output/main.clj
+++ b/src/clj_holmes/output/main.clj
@@ -18,7 +18,8 @@
         json-str (json/write-str json-result :value-fn (fn [key value]
                                                          (case key
                                                            :code (str value)
-                                                           :parent (subs (str value) 1)
+                                                           :parent (when value
+                                                                     (subs (str value) 1))
                                                            value)))]
     (spit output-file json-str)
     json-result))


### PR DESCRIPTION
There are some cases where the value of `:parent` comes as nil and calling `(subs (str nil) 1)` will throw. This adds a check to ignore cases where the parent symbol was not found, given that this is not a required feature.