### PR TITLE
Do not print progress bar when --no-verbose is specified

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.clj-holmes/clj-holmes "1.4.2"
+(defproject org.clojars.clj-holmes/clj-holmes "1.4.3"
   :description "Clojure SAST."
   :url "https://github.com/clj-holmes/clj-holmes"
   :scm {:name "git"

--- a/src/clj_holmes/engine.clj
+++ b/src/clj_holmes/engine.clj
@@ -25,6 +25,7 @@
 
 (defn scan [{:keys [verbose fail-on-result] :as opts}]
   (let [out (if verbose *out* (new StringWriter))]
+    (when verbose (progress/add-watch-to-counter))
     (binding [*out* out]
       (let [result (scan* opts)]
         (when fail-on-result

--- a/src/clj_holmes/logic/progress.clj
+++ b/src/clj_holmes/logic/progress.clj
@@ -5,9 +5,10 @@
 
 (def counter (atom 0))
 
-(add-watch counter
-           :print (fn [_ _ _ new-state]
-                    (-> @bar (pr/tick new-state) pr/print)))
+(defn add-watch-to-counter []
+  (add-watch counter
+             :print (fn [_ _ _ new-state]
+                      (-> @bar (pr/tick new-state) pr/print))))
 
 (defn count-progress-size [files]
   (let [amount-of-files (count files)]

--- a/src/clj_holmes/specs/sarif.clj
+++ b/src/clj_holmes/specs/sarif.clj
@@ -7,7 +7,7 @@
 
 (s/def :driver/name #{"clj-holmes"})
 (s/def :driver/version ::non-blank-string)
-(s/def :driver/informationUri #{"https://github.com/mthbernardes/clj-holmes"})
+(s/def :driver/informationUri #{"https://github.com/clj-holmes/clj-holmes"})
 
 (s/def ::text ::non-blank-string)
 (s/def ::id ::non-blank-string)
@@ -62,7 +62,7 @@
                                  ::locations]))
 (s/def ::results (s/coll-of ::result))
 
-(s/def ::$schema #{"https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Documents/CommitteeSpecifications/2.1.0/sarif-schema-2.1.0.json"})
+(s/def ::$schema #{"https://schemastore.azurewebsites.net/schemas/json/sarif-2.1.0-rtm.5.json"})
 (s/def ::version #{"2.1.0"})
 (s/def ::runs (s/coll-of (s/keys :req-un [::tool
                                           ::results])))


### PR DESCRIPTION
Progress bar shouldn't be shown when `--no-verbose` is passed as a parameter.