### PR TITLE
Bump base docker image

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,6 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Install clojure tools
+        uses: DeLaGuardo/setup-clojure@3.6
+        with:
+          lein: latest
+
       - name: Install dependencies
         run: lein deps
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:xenial-20210416
+FROM ubuntu:resolute-20260413
 
 RUN apt-get update && apt-get upgrade -y
 COPY clj-holmes-ubuntu-latest /bin/clj-holmes


### PR DESCRIPTION
~Docker fails to build with old image because `RUN apt-get update && apt-get upgrade -y ` hangs indefinitely. This is likely due to Ubuntu Xenial's EoL being April 2026.~

This PR also fixes the `test` GitHub workflow by installing the `lein` CLI, which I assume stopped being distributed in default GH action images.